### PR TITLE
fix: upgrade hmarr/auto-approve-actio

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'HsiehShuJeng')
     steps:
-      - uses: hmarr/auto-approve-action@v2.2.1
+      - uses: hmarr/auto-approve-action@v3.2.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -118,8 +118,8 @@ const buildOverridingSteps = {
 };
 
 const approveOverridingSteps = {
-  'jobs.approve.steps.0.uses': 'hmarr/auto-approve-action@v3.2.1'
-}
+  'jobs.approve.steps.0.uses': 'hmarr/auto-approve-action@v3.2.1',
+};
 
 setupWorkflow('build', requiredAwsEnv, buildOverridingSteps);
 setupWorkflow('release', requiredAwsEnv, releaseOverridingSteps);
@@ -156,7 +156,7 @@ function setupWorkflow(workflowName, envOverrides, stepsOverrides) {
     workflow.file.addOverride(step, override);
   }
 
-  if(envOverrides){
+  if (envOverrides) {
     workflow.file.addOverride(`jobs.${workflowName}.env`, envOverrides);
   }
 }

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -99,14 +99,14 @@ const requiredAwsEnv = {
   AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}',
 };
 
-const releaseSteps = {
+const releaseOverridingSteps = {
   'jobs.release.steps.4': {
     name: 'release',
     run: 'export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query \'Account\' | tr -d \'"\')\nexport CDK_DEFAULT_REGION=${AWS_REGION}\nnpx projen release',
   },
 };
 
-const buildSteps = {
+const buildOverridingSteps = {
   'jobs.build.steps.2': {
     name: 'Install dependencies',
     run: 'yarn install --frozen-lockfile',
@@ -117,8 +117,13 @@ const buildSteps = {
   },
 };
 
-setupWorkflow('build', requiredAwsEnv, buildSteps);
-setupWorkflow('release', requiredAwsEnv, releaseSteps);
+const approveOverridingSteps = {
+  'jobs.approve.steps.0.uses': 'hmarr/auto-approve-action@v3.2.1'
+}
+
+setupWorkflow('build', requiredAwsEnv, buildOverridingSteps);
+setupWorkflow('release', requiredAwsEnv, releaseOverridingSteps);
+setupWorkflow('auto-approve', undefined, approveOverridingSteps);
 
 project.package.addPackageResolutions('@types/jest@^27.4.1');
 project.synth();
@@ -141,7 +146,7 @@ function excludeFilesFrom(pjObject, exclusionList) {
  * Set up a GitHub Actions workflow with the specified environment variables and step overrides.
  *
  * @param {string} workflowName - The name of the workflow to configure.
- * @param {Object} envOverrides - An object containing environment variables to override in the workflow.
+ * @param {Object} [envOverrides] - An object containing environment variables to override in the workflow.
  * @param {Object} stepsOverrides - An object where each key is a step identifier (e.g., 'jobs.build.steps.2') and each value is an object containing the step configuration to override.
  */
 function setupWorkflow(workflowName, envOverrides, stepsOverrides) {
@@ -151,5 +156,7 @@ function setupWorkflow(workflowName, envOverrides, stepsOverrides) {
     workflow.file.addOverride(step, override);
   }
 
-  workflow.file.addOverride(`jobs.${workflowName}.env`, envOverrides);
+  if(envOverrides){
+    workflow.file.addOverride(`jobs.${workflowName}.env`, envOverrides);
+  }
 }

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Promise me, darling, make advantage on the CloudFormation outputs.  All you need
    # upload script
    aws s3 cp delta-lake-demo.py s3://${SERVERLESS_BUCKET_NAME}/scripts/${DELTA_LAKE_SCRIPT_NAME}.py --profile ${PROFILE_NAME}
    # download jars and upload them
-   DELTA_VERSION="1.2.0"
-   DELTA_LAKE_CORE="delta-core_2.12-${DELTA_VERSION}.jar"
+   DELTA_VERSION="2.2.0"
+   DELTA_LAKE_CORE="delta-core_2.13-${DELTA_VERSION}.jar"
    DELTA_LAKE_STORAGE="delta-storage-${DELTA_VERSION}.jar"
-   curl https://repo1.maven.org/maven2/io/delta/delta-core_2.12/${DELTA_VERSION}/${DELTA_LAKE_CORE} --output ${DELTA_LAKE_CORE}
+   curl https://repo1.maven.org/maven2/io/delta/delta-core_2.13/${DELTA_VERSION}/${DELTA_LAKE_CORE} --output ${DELTA_LAKE_CORE}
    curl https://repo1.maven.org/maven2/io/delta/delta-storage/${DELTA_VERSION}/${DELTA_LAKE_STORAGE} --output ${DELTA_LAKE_STORAGE}
    aws s3 mv ${DELTA_LAKE_CORE} s3://${SERVERLESS_BUCKET_NAME}/jars/${${DELTA_LAKE_CORE}} --profile ${PROFILE_NAME}
    aws s3 mv ${DELTA_LAKE_STORAGE} s3://${SERVERLESS_BUCKET_NAME}/jars/${DELTA_LAKE_STORAGE} --profile ${PROFILE_NAME}


### PR DESCRIPTION
1. For resolving the following warning:
  ```bash
  Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: hmarr/auto-approve-action@v2.2.1.
  For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
  ```
2. updated README.md